### PR TITLE
Add assertions to validate assumptions in Mavis, Parser and Storage

### DIFF
--- a/src/main/java/mavis/MainWindow.java
+++ b/src/main/java/mavis/MainWindow.java
@@ -23,7 +23,7 @@ public class MainWindow extends AnchorPane {
     private Mavis mavis;
 
     private Image userImage = new Image(this.getClass().getResourceAsStream("/images/DaUser.png"));
-    private Image dukeImage = new Image(this.getClass().getResourceAsStream("/images/DaDuke.png"));
+    private Image mavisImage = new Image(this.getClass().getResourceAsStream("/images/DaDuke.png"));
 
     /**
      * Initializes the main window by binding the scroll pane's value property to the dialog container's height property
@@ -33,7 +33,7 @@ public class MainWindow extends AnchorPane {
     public void initialize() {
         scrollPane.vvalueProperty().bind(dialogContainer.heightProperty());
         dialogContainer.getChildren().addAll(
-            DialogBox.getMavisDialog("Hello! I'm Mavis\nHow can i help you?", dukeImage)
+            DialogBox.getMavisDialog("Hello! I'm Mavis\nHow can i help you?", mavisImage)
         );
     }
 
@@ -52,7 +52,7 @@ public class MainWindow extends AnchorPane {
         String response = mavis.getResponse(input);
         dialogContainer.getChildren().addAll(
                 DialogBox.getUserDialog(input, userImage),
-                DialogBox.getMavisDialog(response, dukeImage)
+                DialogBox.getMavisDialog(response, mavisImage)
         );
         userInput.clear();
     }

--- a/src/main/java/mavis/Mavis.java
+++ b/src/main/java/mavis/Mavis.java
@@ -20,9 +20,12 @@ public class Mavis {
      */
     public Mavis(final String filePath) {
         ui = new Ui();
+        assert ui != null : "Ui should not be null";
         storage = new Storage(filePath);
+        assert storage != null : "Storage should not be null";
         try {
             this.taskList = new TaskList(storage.loadTasks());
+            assert taskList != null : "TaskList should not be null";
         } catch (MavisException e) {
             this.taskList = new TaskList();
             storage.saveTasks(taskList);

--- a/src/main/java/mavis/Parser.java
+++ b/src/main/java/mavis/Parser.java
@@ -29,6 +29,7 @@ public class Parser {
      * @throws MavisException If the input is invalid or the format is incorrect for a task.
      */
     public static Command parse(String... inputs) throws MavisException {
+        assert inputs != null : "Inputs should not be null";
         if (inputs.length == 0 || inputs[0].isEmpty()) {
             throw new MavisException("Input cannot be empty.");
         }

--- a/src/main/java/mavis/Storage.java
+++ b/src/main/java/mavis/Storage.java
@@ -28,6 +28,7 @@ public class Storage {
      * @param filePath The path to the file where tasks are saved.
      */
     public Storage(String filePath) {
+        assert filePath != null && !filePath.isEmpty() : "File path cannot be null or empty";
         this.filePath = filePath;
     }
 
@@ -47,9 +48,8 @@ public class Storage {
             while (scanner.hasNextLine()) {
                 String line = scanner.nextLine();
                 Task task = parseFileTask(line);
-                if (task != null) {
-                    tasksList.add(task);
-                }
+                assert task != null : "Parsed task should never be null";
+                tasksList.add(task);
             }
         } catch (IOException e) {
             System.out.println("An error occurred while loading tasks from the file.");
@@ -74,10 +74,12 @@ public class Storage {
             task = new ToDo(name, isDone);
             break;
         case "D":
+            assert parts.length == 4 : "Deadline task must have 4 parts";
             String by = parts[3];
             task = new Deadline(name, by, isDone);
             break;
         case "E":
+            assert parts.length == 5 : "Event task must have 5 parts";
             String from = parts[3];
             String to = parts[4];
             task = new Event(name, from, to, isDone);
@@ -99,6 +101,7 @@ public class Storage {
         try (FileWriter fw = new FileWriter(filePath)) {
             if (!tasksList.isEmpty()) {
                 for (Task task : tasksList) {
+                    assert task != null : "Task in list should not be null";
                     fw.write(task.saveTask() + System.lineSeparator());
                 }
             }


### PR DESCRIPTION
Assertions are not used to document key assumptions in Parser, Storage, and Mavis.

This makes it harder to catch unexpected errors and verify that critical components are initialized correctly.

Add assertions to ensure critical assumptions hold.
- In Parser, assert that input arrays are not null or empty before parsing.
- In Storage, assert that file paths are not null and parsed tasks are valid.
- In Mavis, assert that UI, Storage, and TaskList are properly initialized.

Assertions help catch logical errors early and improve code reliability without affecting runtime performance in production.